### PR TITLE
docs: add working group charter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# TypeScript Working Group
+
+## Charter
+
+The TypeScript Working Group manages the TypeScript-related aspects of the Express ecosystem,
+providing guidance, support, and resources for TypeScript users and contributors.
+
+### Responsibilities
+
+- Ensure express package types are semantically correct, current with the implementation,
+and provide a high-quality developer experience
+- Maintaining up-to-date TypeScript type definitions
+- Enhancing documentation for TypeScript usage across Express packages
+- Ensure that types shared across Express Project packages are updated in sync to prevent
+build errors across the ecosystem
+- Work with the maintainers of each package to decide whether to include the types within
+the package or in DefinitelyTyped
+  - Support testing type accuracy while in development and CI
+
+## Current Initiatives
+
+Create a table with the current initiatives of the TypeScript Working Group.
+Each initiative should have a title, description, and a link to the issue tracking it.
+
+| Initiative | Champion | Status | Links |
+| ---------- | -------- | ------ | ----- |
+|            |          |        |       |
+
+## Members
+
+The TypeScript Working Group is made up of volunteers, you do not need to be a member to participate,
+but once you participate please open a PR to add yourself here.
+
+Two teams exist for mentioning the group and managing access:
+
+- @expressjs/typescript-wg: everyone participating in the WG has write access to this repo
+- @expressjs/typescript-wg-captains: the repository captians as per Express project guidelines
+
+### Team Members
+
+- [Jon Church](https://github.com/jonchurch) (Captain)
+- [Sebastian Beltran](https://github.com/bjohansebas) (Captain)
+
+## Meetings
+
+The TypeScript Working Group meets on an ad hoc basis. The meeting is open to the public.
+The agenda and meeting notes are published in this repository.
+
+## Offline Discussions
+
+The TypeScript Working Group uses [GitHub Discussions](https://github.com/expressjs/typescript-wg/discussions)
+for offline discussion. The discussions are open to the public and anyone may participate. Also, the group uses
+the channel #express-ts-wg in the [OpenJS Foundation Slack](https://openjsf.org/collaboration) for realtime
+discussions.
+
+## Code of Conduct
+
+The Express Project's CoC applies to this repo.


### PR DESCRIPTION
This is the charter created based on the proposal in https://github.com/expressjs/discussions/blob/master/docs/adr/typescript-wg.md. Feel free to share your thoughts on the scope of this group

cc: @expressjs/express-tc @RobinTail @clicktodev @raphendyr